### PR TITLE
Added trap signal Ctrl+C on lab Makefile

### DIFF
--- a/labs/file-dir-monitor/lab.mk
+++ b/labs/file-dir-monitor/lab.mk
@@ -2,11 +2,15 @@
 
 APP_NAME=monitor
 LIB_NAME=logger
+
+test:
+	bash -c "trap -- '' SIGINT; $(MAKE) test-t"
+
 build:
 	gcc -c ${APP_NAME}.c -o ${APP_NAME}.o
 	gcc -c ${LIB_NAME}.c -o ${LIB_NAME}.o
 	gcc    ${LIB_NAME}.o ${APP_NAME}.o  -o ${APP_NAME}
-test: build
+test-t: build
 	 @echo Test 1
 	sudo ./${APP_NAME} /tmp
 	@echo Test 2


### PR DESCRIPTION
### Explanation
When we send the signal to stop the program, makefile catches the same signal too and stops the test, this way we cannot run all the tests with the same script. The way to solve it is to catch a particular signal to use, in this case Ctrl+C, and make the program exit with that but trap the signal so that GNU make do not stop.